### PR TITLE
Correctly set XP version in jar file (#4)

### DIFF
--- a/src/main/java/com/enonic/gradle/xp/app/AppExtension.java
+++ b/src/main/java/com/enonic/gradle/xp/app/AppExtension.java
@@ -27,7 +27,7 @@ public class AppExtension
 
     private String vendorUrl;
 
-    private String systemVersion = "[6.0,7)";
+    private String systemVersion;
 
     private Map<String, String> instructions;
 


### PR DESCRIPTION
When using this version of the plugin, the version needs to be added to build.gradle, using the `systemVersion` property:

```
app {
    name = 'com.enonic.app.myapp'
    displayName = 'My App'
    vendorName = 'Enonic AS'
    vendorUrl = 'http://enonic.com'
    systemVersion = "${xpVersion}"   <--
}

```