### PR TITLE
Add support for raw dev source paths

### DIFF
--- a/src/main/java/com/enonic/gradle/xp/app/AppExtension.java
+++ b/src/main/java/com/enonic/gradle/xp/app/AppExtension.java
@@ -32,6 +32,8 @@ public class AppExtension
     private Map<String, String> instructions;
 
     private List<File> devSourcePaths;
+    
+    private List<String> rawDevSourcePaths;
 
     private boolean systemApp;
 
@@ -45,6 +47,8 @@ public class AppExtension
         this.devSourcePaths = new ArrayList<>();
         addDevSourcePath( this.project.getProjectDir(), "src", "main", "resources" );
         addDevSourcePath( this.project.getBuildDir(), "resources", "main" );
+
+        this.rawDevSourcePaths = new ArrayList<>();
 
         this.systemApp = false;
         this.capabilities = new HashSet<>();
@@ -125,6 +129,16 @@ public class AppExtension
     public void setDevSourcePaths( final List<File> devSourcePaths )
     {
         this.devSourcePaths = devSourcePaths;
+    }
+
+    public List<String> getRawDevSourcePaths()
+    {
+        return this.rawDevSourcePaths;
+    }
+
+    public void setRawDevSourcePaths( final List<String> rawDevSourcePaths )
+    {
+        this.rawDevSourcePaths = rawDevSourcePaths;
     }
 
     public Map<String, String> getInstructions()

--- a/src/main/java/com/enonic/gradle/xp/app/BundleConfigurator.java
+++ b/src/main/java/com/enonic/gradle/xp/app/BundleConfigurator.java
@@ -13,6 +13,7 @@ import org.gradle.api.artifacts.Configuration;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
 
 import aQute.bnd.gradle.BundleTaskConvention;
 
@@ -75,7 +76,7 @@ final class BundleConfigurator
         }
 
         includeWebJars();
-        addDevSourcePaths( application.getDevSourcePaths() );
+        addDevSourcePaths( application.getDevSourcePaths(), application.getRawDevSourcePaths() );
     }
 
     private void instruction( final String name, final Object value )
@@ -131,10 +132,12 @@ final class BundleConfigurator
         instruction( "Include-Resource", "/assets=" + webjarsDir.getAbsolutePath().replace( File.separatorChar, '/' ) );
     }
 
-    private void addDevSourcePaths( final List<File> paths )
+    private void addDevSourcePaths( final List<File> paths, final List<String> rawPaths )
     {
         final Iterator<String> it =
             paths.stream().map( File::getAbsolutePath ).map( absolutePath -> absolutePath.replace( File.separatorChar, '/' ) ).iterator();
-        instruction( "X-Source-Paths", Joiner.on( ',' ).join( it ) );
+        final List<String> li = Lists.newArrayList( it );
+        li.addAll( rawPaths );
+        instruction( "X-Source-Paths", Joiner.on( ',' ).join( li ) );
     }
 }


### PR DESCRIPTION
Adds support for raw, unmodified dev source paths to the gradle plugin.

When running development servers inside Docker containers on Windows, X-Source-Paths will contain an absolute Windows path (C:/<path>). While this is desirable in most cases, there should be an option to add raw, unmodified paths to X-Source-Paths.