### PR TITLE
Preserve archive file timestamps for app/lib builds

### DIFF
--- a/src/main/java/com/enonic/gradle/xp/BasePlugin.java
+++ b/src/main/java/com/enonic/gradle/xp/BasePlugin.java
@@ -4,6 +4,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 public final class BasePlugin
@@ -18,5 +19,7 @@ public final class BasePlugin
             final JavaPluginExtension javaExt = project.getExtensions().getByType( JavaPluginExtension.class );
             javaExt.getToolchain().getLanguageVersion().convention( JavaLanguageVersion.of( 25 ) );
         } );
+
+        project.getTasks().withType( AbstractArchiveTask.class ).configureEach( task -> task.setPreserveFileTimestamps( true ) );
     }
 }

--- a/src/test/java/com/enonic/gradle/xp/BasePluginTest.java
+++ b/src/test/java/com/enonic/gradle/xp/BasePluginTest.java
@@ -1,0 +1,28 @@
+package com.enonic.gradle.xp;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BasePluginTest
+{
+    @Test
+    void preservesFileTimestampsOnArchiveTasks()
+    {
+        final Project project = ProjectBuilder.builder().build();
+        project.getPlugins().apply( JavaPlugin.class );
+
+        final Jar jar = (Jar) project.getTasks().getByName( "jar" );
+        // Gradle 9 defaults preserveFileTimestamps to false (reproducible builds). Set it
+        // explicitly here to prove the plugin actively forces the value back to true.
+        jar.setPreserveFileTimestamps( false );
+
+        project.getPlugins().apply( BasePlugin.class );
+
+        assertTrue( jar.isPreserveFileTimestamps(), "BasePlugin should preconfigure preserveFileTimestamps = true on archive tasks" );
+    }
+}


### PR DESCRIPTION
Gradle 9 flipped the `preserveFileTimestamps` default to `false` (reproducible archives dated 1980-02-01). Enonic XP derives the `portal.assetUrl()` fingerprint from JAR entry timestamps, so the fingerprint froze at `0000004a16dd9400` and immutable-cached assets never updated between releases.

This sets `preserveFileTimestamps = true` on all archive tasks in the base plugin, so both library and application builds get real per-build timestamps again.

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
