### PR TITLE
Configurable xpVersion with 8.0.2 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ pluginManagement {
 }
 
 plugins {
-    id("com.enonic.xp.settings") version "4.0.0-SNAPSHOT"
+    id("com.enonic.xp.settings") version "4.1.0-SNAPSHOT"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For Enonic XP 8.x, use version 4.0.0 or later.
 
 This repository provides three plugins:
 
-- **`com.enonic.xp.settings`** — registers the `xplibs` version catalog with Enonic XP dependencies. The XP version is taken from the `xp { version = "…" }` settings block, then the `xpVersion` Gradle property, defaulting to `8.0.2`.
+- **`com.enonic.xp.settings`** — registers the `xplibs` version catalog with Enonic XP dependencies. The XP version is taken from the `xp { version = "…" }` settings block, then the `xpVersion` Gradle property, falling back to a built-in default version.
 - **`com.enonic.xp.base`** — base plugin for library and application development (Enonic repositories, the `xp {}` extension, Java toolchain).
 - **`com.enonic.xp.app`** — builds Enonic XP application jar files (automatically applies the base plugin).
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For Enonic XP 8.x, use version 4.0.0 or later.
 
 This repository provides three plugins:
 
-- **`com.enonic.xp.settings`** — registers the `xplibs` version catalog with Enonic XP dependencies.
+- **`com.enonic.xp.settings`** — registers the `xplibs` version catalog with Enonic XP dependencies. The XP version is taken from the `xp { version = "…" }` settings block, then the `xpVersion` Gradle property, defaulting to `8.0.2`.
 - **`com.enonic.xp.base`** — base plugin for library and application development (Enonic repositories, the `xp {}` extension, Java toolchain).
 - **`com.enonic.xp.app`** — builds Enonic XP application jar files (automatically applies the base plugin).
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.launcher)
     testImplementation(libs.mockito.jupiter)
+    testImplementation(gradleTestKit())
 }
 
 java {

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -22,12 +22,27 @@ plugins {
 
 === Usage
 
-Define `xpVersion` in `gradle.properties`:
+Set the XP version (optional, defaults to `8.0.2`) either in `settings.gradle`:
+
+[source,groovy]
+----
+plugins {
+  id 'com.enonic.xp.settings' version '4.1.0'
+}
+
+xp {
+  version = '8.5.0'
+}
+----
+
+or via `gradle.properties`:
 
 [source,properties]
 ----
-xpVersion = 8.0.0
+xpVersion = 8.5.0
 ----
+
+The settings block takes precedence over the Gradle property; if neither is set, `8.0.2` is used.
 
 The plugin creates a `xplibs` version catalog with Enonic XP dependencies.
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -88,7 +88,7 @@ The base plugin creates the `xp {}` extension:
 [source,groovy]
 ----
 xp {
-    version = "8.0.0" // in case you need to override `xpVersion` from `gradle.properties`
+    version = "8.5.0" // optional; overrides the resolved XP version (the `xplibs` catalog, then `xpVersion` property, then `8.0.2`)
     homeDir = file("/path/to/xp/home")  // in case you need to override XP home directory
 }
 ----
@@ -98,7 +98,7 @@ xp {
 | Property | Default | Description
 
 | `version`
-| `xpVersion` from `gradle.properties`
+| the `xplibs` catalog version, then the `xpVersion` Gradle property, then `8.0.2`
 | XP version
 
 | `homeDir`
@@ -194,12 +194,7 @@ You can find more information about packaging in https://bnd.bndtools.org/heads/
 `webjar` dependencies content (`META-INF/resources/webjars` ) is placed into `/assets` folder inside the resulting jar file.
 You can find more information about WebJars on https://www.webjars.org/
 
-NOTE: Usually `xpVersion` property is defined in `gradle.properties`
-
-[source,properties]
-----
-xpVersion=8.0.0
-----
+NOTE: The XP version is optional. It resolves from the `xp { version }` block in the Settings plugin, then the `xpVersion` Gradle property, then defaults to `8.0.2`.
 
 ==== Building application
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -16,7 +16,7 @@ Apply the plugin in your `settings.gradle` file:
 [source,groovy]
 ----
 plugins {
-  id 'com.enonic.xp.settings' version '4.0.0'
+  id 'com.enonic.xp.settings' version '4.1.0'
 }
 ----
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -22,7 +22,7 @@ plugins {
 
 === Usage
 
-Set the XP version (optional, defaults to `8.0.2`) either in `settings.gradle`:
+Set the XP version (optional; falls back to a built-in default) either in `settings.gradle`:
 
 [source,groovy]
 ----
@@ -42,7 +42,7 @@ or via `gradle.properties`:
 xpVersion = 8.5.0
 ----
 
-The settings block takes precedence over the Gradle property; if neither is set, `8.0.2` is used.
+The settings block takes precedence over the Gradle property; if neither is set, a built-in default version is used.
 
 The plugin creates a `xplibs` version catalog with Enonic XP dependencies.
 
@@ -88,7 +88,7 @@ The base plugin creates the `xp {}` extension:
 [source,groovy]
 ----
 xp {
-    version = "8.5.0" // optional; overrides the resolved XP version (the `xplibs` catalog, then `xpVersion` property, then `8.0.2`)
+    version = "8.5.0" // optional; overrides the resolved XP version (the `xplibs` catalog, then `xpVersion` property, then a built-in default)
     homeDir = file("/path/to/xp/home")  // in case you need to override XP home directory
 }
 ----
@@ -98,7 +98,7 @@ xp {
 | Property | Default | Description
 
 | `version`
-| the `xplibs` catalog version, then the `xpVersion` Gradle property, then `8.0.2`
+| the `xplibs` catalog version, then the `xpVersion` Gradle property, then a built-in default
 | XP version
 
 | `homeDir`
@@ -194,7 +194,7 @@ You can find more information about packaging in https://bnd.bndtools.org/heads/
 `webjar` dependencies content (`META-INF/resources/webjars` ) is placed into `/assets` folder inside the resulting jar file.
 You can find more information about WebJars on https://www.webjars.org/
 
-NOTE: The XP version is optional. It resolves from the `xp { version }` block in the Settings plugin, then the `xpVersion` Gradle property, then defaults to `8.0.2`.
+NOTE: The XP version is optional. It resolves from the `xp { version }` block in the Settings plugin, then the `xpVersion` Gradle property, then a built-in default.
 
 ==== Building application
 

--- a/src/main/java/com/enonic/gradle/xp/BasePlugin.java
+++ b/src/main/java/com/enonic/gradle/xp/BasePlugin.java
@@ -4,6 +4,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 public final class BasePlugin
@@ -18,5 +19,7 @@ public final class BasePlugin
             final JavaPluginExtension javaExt = project.getExtensions().getByType( JavaPluginExtension.class );
             javaExt.getToolchain().getLanguageVersion().convention( JavaLanguageVersion.of( 25 ) );
         } );
+
+        project.getTasks().withType( AbstractArchiveTask.class ).configureEach( task -> task.setPreserveFileTimestamps( true ) );
     }
 }

--- a/src/main/java/com/enonic/gradle/xp/SettingsPlugin.java
+++ b/src/main/java/com/enonic/gradle/xp/SettingsPlugin.java
@@ -2,7 +2,6 @@ package com.enonic.gradle.xp;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.initialization.Settings;
-import org.gradle.api.provider.Provider;
 
 public final class SettingsPlugin
     implements Plugin<Settings>
@@ -22,12 +21,15 @@ public final class SettingsPlugin
     @Override
     public void apply( final Settings settings )
     {
-        final Provider<String> xpVersion = settings.getProviders().gradleProperty( "xpVersion" );
-        if ( xpVersion.isPresent() )
-        {
-            settings.dependencyResolutionManagement( drm -> drm.versionCatalogs( container -> {
+        final XpSettingsExtension ext = settings.getExtensions().create( "xp", XpSettingsExtension.class );
+
+        settings.getGradle().settingsEvaluated( evaluated -> {
+            final String version = XpVersionResolver.resolveVersion( ext.getVersion().getOrNull(),
+                                                                     evaluated.getProviders().gradleProperty( "xpVersion" ).getOrNull() );
+
+            evaluated.dependencyResolutionManagement( drm -> drm.versionCatalogs( container -> {
                 container.create( CATALOG_NAME, catalog -> {
-                    catalog.version( "xp", xpVersion.get() );
+                    catalog.version( "xp", version );
                     for ( final String api : XP_APIS )
                     {
                         final String alias = "api-" + api.substring( 0, api.indexOf( '-' ) );
@@ -40,6 +42,6 @@ public final class SettingsPlugin
                     }
                 } );
             } ) );
-        }
+        } );
     }
 }

--- a/src/main/java/com/enonic/gradle/xp/XpExtension.java
+++ b/src/main/java/com/enonic/gradle/xp/XpExtension.java
@@ -3,6 +3,7 @@ package com.enonic.gradle.xp;
 import java.io.File;
 
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.VersionCatalogsExtension;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
@@ -21,7 +22,9 @@ public class XpExtension
         this.project = project;
         final ObjectFactory objects = project.getObjects();
         this.version = objects.property( String.class );
-        this.version.convention( project.getProviders().gradleProperty( "xpVersion" ) );
+        this.version.convention( project.provider(
+            () -> XpVersionResolver.resolveVersion( xplibsCatalogVersion( project ),
+                                                    project.getProviders().gradleProperty( "xpVersion" ).getOrNull() ) ) );
 
         this.homeDir = objects.directoryProperty();
         this.homeDir.convention( project.getProviders()
@@ -30,6 +33,19 @@ public class XpExtension
                                      .orElse( project.getProviders().environmentVariable( "XP_HOME" ) )
                                      .map( path -> objects.directoryProperty().fileValue( new File( path ) ).get() )
                                      .orElse( project.getLayout().getBuildDirectory().dir( "xp/home" ) ) );
+    }
+
+    private static String xplibsCatalogVersion( final Project project )
+    {
+        final VersionCatalogsExtension catalogs = project.getExtensions().findByType( VersionCatalogsExtension.class );
+        if ( catalogs == null )
+        {
+            return null;
+        }
+        return catalogs.find( "xplibs" )
+            .flatMap( catalog -> catalog.findVersion( "xp" ) )
+            .map( version -> version.getRequiredVersion() )
+            .orElse( null );
     }
 
     public Property<String> getVersion()

--- a/src/main/java/com/enonic/gradle/xp/XpExtension.java
+++ b/src/main/java/com/enonic/gradle/xp/XpExtension.java
@@ -42,7 +42,7 @@ public class XpExtension
         {
             return null;
         }
-        return catalogs.find( "xplibs" )
+        return catalogs.find( SettingsPlugin.CATALOG_NAME )
             .flatMap( catalog -> catalog.findVersion( "xp" ) )
             .map( version -> version.getRequiredVersion() )
             .orElse( null );

--- a/src/main/java/com/enonic/gradle/xp/XpSettingsExtension.java
+++ b/src/main/java/com/enonic/gradle/xp/XpSettingsExtension.java
@@ -1,0 +1,8 @@
+package com.enonic.gradle.xp;
+
+import org.gradle.api.provider.Property;
+
+public interface XpSettingsExtension
+{
+    Property<String> getVersion();
+}

--- a/src/main/java/com/enonic/gradle/xp/XpVersionResolver.java
+++ b/src/main/java/com/enonic/gradle/xp/XpVersionResolver.java
@@ -1,0 +1,28 @@
+package com.enonic.gradle.xp;
+
+final class XpVersionResolver
+{
+    static final String DEFAULT_XP_VERSION = "8.0.2";
+
+    private XpVersionResolver()
+    {
+    }
+
+    static String resolveVersion( final String primary, final String property )
+    {
+        if ( isPresent( primary ) )
+        {
+            return primary.trim();
+        }
+        if ( isPresent( property ) )
+        {
+            return property.trim();
+        }
+        return DEFAULT_XP_VERSION;
+    }
+
+    private static boolean isPresent( final String value )
+    {
+        return value != null && !value.isBlank();
+    }
+}

--- a/src/main/java/com/enonic/gradle/xp/app/AppPlugin.java
+++ b/src/main/java/com/enonic/gradle/xp/app/AppPlugin.java
@@ -70,11 +70,6 @@ public final class AppPlugin
     private XpVersion getXpVersion()
     {
         final String version = appExt.getSystemVersion().map( String::trim ).orElse( "" ).get();
-        if ( version.isEmpty() )
-        {
-            throw new IllegalArgumentException(
-                "XP system version not specified. Please set xpVersion in gradle.properties or configure app { systemVersion = \"...\" }" );
-        }
         final XpVersion xpVersion = XpVersion.parse( version );
         if ( !xpVersion.valid )
         {

--- a/src/test/java/com/enonic/gradle/xp/BasePluginTest.java
+++ b/src/test/java/com/enonic/gradle/xp/BasePluginTest.java
@@ -1,0 +1,28 @@
+package com.enonic.gradle.xp;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.bundling.Jar;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BasePluginTest
+{
+    @Test
+    void preservesFileTimestampsOnArchiveTasks()
+    {
+        final Project project = ProjectBuilder.builder().build();
+        project.getPlugins().apply( JavaPlugin.class );
+
+        final Jar jar = (Jar) project.getTasks().getByName( "jar" );
+        // Gradle 9 defaults preserveFileTimestamps to false (reproducible builds). Set it
+        // explicitly here to prove the plugin actively forces the value back to true.
+        jar.setPreserveFileTimestamps( false );
+
+        project.getPlugins().apply( BasePlugin.class );
+
+        assertTrue( jar.isPreserveFileTimestamps(), "BasePlugin should preconfigure preserveFileTimestamps = true on archive tasks" );
+    }
+}

--- a/src/test/java/com/enonic/gradle/xp/SettingsPluginFunctionalTest.java
+++ b/src/test/java/com/enonic/gradle/xp/SettingsPluginFunctionalTest.java
@@ -1,0 +1,70 @@
+package com.enonic.gradle.xp;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SettingsPluginFunctionalTest
+{
+    @TempDir
+    File projectDir;
+
+    private static final String BUILD_GRADLE =
+        "plugins { id 'com.enonic.xp.base' }\n" +
+        "tasks.register('printXpVersion') {\n" +
+        "    doLast { println 'XPVER=' + project.extensions.getByType( com.enonic.gradle.xp.XpExtension ).version.get() }\n" +
+        "}\n";
+
+    private void writeFile( final String name, final String content )
+        throws IOException
+    {
+        Files.writeString( new File( projectDir, name ).toPath(), content );
+    }
+
+    private BuildResult run()
+    {
+        return GradleRunner.create()
+            .withProjectDir( projectDir )
+            .withPluginClasspath()
+            .withArguments( "printXpVersion", "-q" )
+            .build();
+    }
+
+    @Test
+    void settingsExtensionVersionIsUsed()
+        throws IOException
+    {
+        writeFile( "settings.gradle", "plugins { id 'com.enonic.xp.settings' }\n" + "xp { version = '8.5.0' }\n" );
+        writeFile( "build.gradle", BUILD_GRADLE );
+
+        assertTrue( run().getOutput().contains( "XPVER=8.5.0" ) );
+    }
+
+    @Test
+    void gradlePropertyUsedWhenNoExtension()
+        throws IOException
+    {
+        writeFile( "settings.gradle", "plugins { id 'com.enonic.xp.settings' }\n" );
+        writeFile( "build.gradle", BUILD_GRADLE );
+        writeFile( "gradle.properties", "xpVersion=8.4.0\n" );
+
+        assertTrue( run().getOutput().contains( "XPVER=8.4.0" ) );
+    }
+
+    @Test
+    void defaultVersionWhenNothingConfigured()
+        throws IOException
+    {
+        writeFile( "settings.gradle", "plugins { id 'com.enonic.xp.settings' }\n" );
+        writeFile( "build.gradle", BUILD_GRADLE );
+
+        assertTrue( run().getOutput().contains( "XPVER=8.0.2" ) );
+    }
+}

--- a/src/test/java/com/enonic/gradle/xp/XpExtensionTest.java
+++ b/src/test/java/com/enonic/gradle/xp/XpExtensionTest.java
@@ -1,0 +1,29 @@
+package com.enonic.gradle.xp;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class XpExtensionTest
+{
+    @Test
+    void versionDefaultsTo802WhenNoCatalogAndNoProperty()
+    {
+        final Project project = ProjectBuilder.builder().build();
+        final XpExtension ext = XpExtension.create( project );
+
+        assertEquals( "8.0.2", ext.getVersion().get() );
+    }
+
+    @Test
+    void explicitVersionOverridesConvention()
+    {
+        final Project project = ProjectBuilder.builder().build();
+        final XpExtension ext = XpExtension.create( project );
+        ext.setVersion( "8.3.0" );
+
+        assertEquals( "8.3.0", ext.getVersion().get() );
+    }
+}

--- a/src/test/java/com/enonic/gradle/xp/XpVersionResolverTest.java
+++ b/src/test/java/com/enonic/gradle/xp/XpVersionResolverTest.java
@@ -1,0 +1,38 @@
+package com.enonic.gradle.xp;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class XpVersionResolverTest
+{
+    @Test
+    void defaultsWhenBothMissing()
+    {
+        assertEquals( "8.0.2", XpVersionResolver.resolveVersion( null, null ) );
+    }
+
+    @Test
+    void primaryWinsOverProperty()
+    {
+        assertEquals( "8.5.0", XpVersionResolver.resolveVersion( "8.5.0", "8.4.0" ) );
+    }
+
+    @Test
+    void propertyUsedWhenNoPrimary()
+    {
+        assertEquals( "8.4.0", XpVersionResolver.resolveVersion( null, "8.4.0" ) );
+    }
+
+    @Test
+    void blankPrimaryFallsThroughToProperty()
+    {
+        assertEquals( "8.4.0", XpVersionResolver.resolveVersion( "   ", "8.4.0" ) );
+    }
+
+    @Test
+    void valuesAreTrimmed()
+    {
+        assertEquals( "8.5.0", XpVersionResolver.resolveVersion( "  8.5.0  ", null ) );
+    }
+}


### PR DESCRIPTION
Adds a configurable XP version with a single resolution chain.

- New `xp { version = "..." }` DSL on the settings plugin (`com.enonic.xp.settings`).
- `SettingsPlugin` now **always** creates the `xplibs` catalog, with the version resolved as: settings `xp { version }` → `xpVersion` Gradle property → `8.0.2`.
- `XpExtension.version` resolves the same chain (reads the `xplibs` catalog when the optional settings plugin is applied, then the property, then `8.0.2`).
- `xpVersion` is no longer required; `AppPlugin` no longer fails when it is unset.

Covered by unit tests (resolver, `XpExtension`) and Gradle TestKit functional tests across all three precedence branches.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
