### PR TITLE
Derive the script-engine test matrix from the project

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -90,6 +90,7 @@ The base plugin creates the `xp {}` extension:
 xp {
     version = "8.5.0" // optional; overrides the resolved XP version (the `xplibs` catalog, then `xpVersion` property, then a built-in default)
     homeDir = file("/path/to/xp/home")  // in case you need to override XP home directory
+    scriptEngines = ['Nashorn']         // optional; overrides which script engines the tests run on
 }
 ----
 
@@ -104,7 +105,35 @@ xp {
 | `homeDir`
 | `xpHome` gradle property, `xp.home` system property, `XP_HOME` env variable, or `${buildDir}/xp/home`
 | XP home directory
+
+| `scriptEngines`
+| every supported engine for a library; the engine declared in `app { scriptEngine }` for an application
+| the script engines the tests run on
 |===
+
+==== Script engine tests
+
+A library is required by applications running on any script engine, so its tests run on all of them:
+`test` uses the first engine and each remaining one gets a task of its own, such as `testGraalJS`,
+all reachable from `check`.
+
+An application runs on the single engine it declares in `app { scriptEngine }`, so its tests run on
+that engine alone. That is the same value that becomes the application's `X-Script-Engine` manifest
+header, so what is tested cannot drift from what is deployed. An application that declares no engine
+is left alone, and its tests follow whatever the XP version it builds against defaults to.
+
+Every task names its engine explicitly rather than letting `test` inherit the platform default. Were
+it to inherit, the day XP changes its default every task would run the new default and coverage of
+the other engine would disappear without any test failing.
+
+Override this with `scriptEngines`, for instance in a library that genuinely supports one engine:
+
+[source,groovy]
+----
+xp {
+    scriptEngines = ['Nashorn']
+}
+----
 
 === Usage
 

--- a/src/main/java/com/enonic/gradle/xp/BasePlugin.java
+++ b/src/main/java/com/enonic/gradle/xp/BasePlugin.java
@@ -21,5 +21,7 @@ public final class BasePlugin
         } );
 
         project.getTasks().withType( AbstractArchiveTask.class ).configureEach( task -> task.setPreserveFileTimestamps( true ) );
+
+        ScriptEngineTests.configure( project );
     }
 }

--- a/src/main/java/com/enonic/gradle/xp/ScriptEngineTests.java
+++ b/src/main/java/com/enonic/gradle/xp/ScriptEngineTests.java
@@ -1,0 +1,114 @@
+package com.enonic.gradle.xp;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.testing.Test;
+import org.gradle.api.tasks.testing.junit.JUnitOptions;
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
+import org.gradle.api.tasks.testing.testng.TestNGOptions;
+import org.gradle.language.base.plugins.LifecycleBasePlugin;
+
+/**
+ * Gives a project one test run per script engine it has to support, so no build has to write that
+ * matrix itself.
+ * <p>
+ * Which engines those are is a property of the project, and only the build knows it: a library runs
+ * inside whatever application requires it, so it has to pass on all of them, while an application
+ * runs on exactly the one engine it declares. The declared engine lives in {@code app.scriptEngine}
+ * and reaches production as the {@code X-Script-Engine} bundle header — the same value decides the
+ * tests, so the two can never drift.
+ */
+final class ScriptEngineTests
+{
+    /**
+     * The system property the XP test harness reads to pick an engine.
+     */
+    private static final String SCRIPT_ENGINE_PROPERTY = "xp.script-engine";
+
+    private ScriptEngineTests()
+    {
+    }
+
+    static void configure( final Project project )
+    {
+        project.getPlugins().withType( JavaPlugin.class, javaPlugin -> project.afterEvaluate( ScriptEngineTests::apply ) );
+    }
+
+    private static void apply( final Project project )
+    {
+        final List<String> engines = XpExtension.get( project ).getScriptEngines().get();
+        if ( engines.isEmpty() )
+        {
+            // nothing declared and nothing to default to: leave `test` untouched so it follows the
+            // engine the XP version being built against defaults to
+            return;
+        }
+
+        final TaskProvider<Test> test = project.getTasks().named( JavaPlugin.TEST_TASK_NAME, Test.class );
+
+        // Name the engine on `test` rather than letting it inherit the platform default. If it
+        // inherited, the day XP changes its default both this task and the extra ones below would
+        // run the new default and coverage of the other engine would vanish without a failure.
+        test.configure( task -> task.systemProperty( SCRIPT_ENGINE_PROPERTY, engines.get( 0 ) ) );
+
+        for ( final String engine : engines.subList( 1, engines.size() ) )
+        {
+            registerEngineTest( project, test, engine );
+        }
+    }
+
+    private static void registerEngineTest( final Project project, final TaskProvider<Test> test, final String engine )
+    {
+        final SourceSet testSourceSet = project.getExtensions()
+            .getByType( JavaPluginExtension.class )
+            .getSourceSets()
+            .getByName( SourceSet.TEST_SOURCE_SET_NAME );
+
+        final TaskProvider<Test> engineTest = project.getTasks().register( taskName( engine ), Test.class, task -> {
+            task.setGroup( LifecycleBasePlugin.VERIFICATION_GROUP );
+            task.setDescription( "Runs the tests with the " + engine + " script engine." );
+            task.setTestClassesDirs( testSourceSet.getOutput().getClassesDirs() );
+            task.setClasspath( testSourceSet.getRuntimeClasspath() );
+            task.systemProperty( SCRIPT_ENGINE_PROPERTY, engine );
+            useSameFrameworkAs( task, test.get() );
+
+            // the same classes on the same output directories: two engines at once would have them
+            // writing over each other's results
+            task.shouldRunAfter( test );
+        } );
+
+        project.getTasks().named( LifecycleBasePlugin.CHECK_TASK_NAME ).configure( check -> check.dependsOn( engineTest ) );
+    }
+
+    /**
+     * A registered {@link Test} task does not inherit the test framework the build selected for
+     * {@code test}, and guessing wrong means it silently finds no tests at all.
+     */
+    private static void useSameFrameworkAs( final Test task, final Test test )
+    {
+        final Object options = test.getOptions();
+        if ( options instanceof JUnitPlatformOptions )
+        {
+            task.useJUnitPlatform();
+        }
+        else if ( options instanceof JUnitOptions )
+        {
+            task.useJUnit();
+        }
+        else if ( options instanceof TestNGOptions )
+        {
+            task.useTestNG();
+        }
+    }
+
+    private static String taskName( final String engine )
+    {
+        return "test" + engine.substring( 0, 1 ).toUpperCase( Locale.ROOT ) + engine.substring( 1 );
+    }
+}

--- a/src/main/java/com/enonic/gradle/xp/SettingsPlugin.java
+++ b/src/main/java/com/enonic/gradle/xp/SettingsPlugin.java
@@ -40,6 +40,8 @@ public final class SettingsPlugin
                         final String alias = lib.substring( 4 );
                         catalog.library( alias, XP_GROUP, lib ).versionRef( "xp" );
                     }
+                    // the script test harness, so builds stop spelling out the coordinate and its version
+                    catalog.library( "testing", XP_GROUP, "testing" ).versionRef( "xp" );
                 } );
             } ) );
         } );

--- a/src/main/java/com/enonic/gradle/xp/XpExtension.java
+++ b/src/main/java/com/enonic/gradle/xp/XpExtension.java
@@ -1,21 +1,31 @@
 package com.enonic.gradle.xp;
 
 import java.io.File;
+import java.util.List;
 
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.VersionCatalogsExtension;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 
 public class XpExtension
 {
+    /**
+     * What a library is tested on by default. A library declares no engine of its own — it runs
+     * inside whatever application requires it — so its tests have to pass on every engine.
+     */
+    private static final List<String> ALL_SCRIPT_ENGINES = List.of( "Nashorn", "GraalJS" );
+
     private final Project project;
 
     private final Property<String> version;
 
     private final DirectoryProperty homeDir;
+
+    private final ListProperty<String> scriptEngines;
 
     public XpExtension( final Project project )
     {
@@ -33,6 +43,9 @@ public class XpExtension
                                      .orElse( project.getProviders().environmentVariable( "XP_HOME" ) )
                                      .map( path -> objects.directoryProperty().fileValue( new File( path ) ).get() )
                                      .orElse( project.getLayout().getBuildDirectory().dir( "xp/home" ) ) );
+
+        this.scriptEngines = objects.listProperty( String.class );
+        this.scriptEngines.convention( ALL_SCRIPT_ENGINES );
     }
 
     private static String xplibsCatalogVersion( final Project project )
@@ -66,6 +79,22 @@ public class XpExtension
     public void setHomeDir( final File dir )
     {
         this.homeDir.set( dir );
+    }
+
+    /**
+     * The script engines the tests of this project run on, in order: the first is the one the
+     * {@code test} task uses, and every other one gets a task of its own. An application narrows
+     * this to the single engine it declares; an empty list leaves {@code test} alone, so it follows
+     * the default of the XP version being built against.
+     */
+    public ListProperty<String> getScriptEngines()
+    {
+        return this.scriptEngines;
+    }
+
+    public void setScriptEngines( final List<String> scriptEngines )
+    {
+        this.scriptEngines.set( scriptEngines );
     }
 
     public static XpExtension get( final Project project )

--- a/src/main/java/com/enonic/gradle/xp/app/AppPlugin.java
+++ b/src/main/java/com/enonic/gradle/xp/app/AppPlugin.java
@@ -1,5 +1,6 @@
 package com.enonic.gradle.xp.app;
 
+import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -37,6 +38,12 @@ public final class AppPlugin
         this.ext = XpExtension.get( this.project );
         this.appExt = AppExtension.create( this.project );
         this.appExt.getSystemVersion().convention( this.ext.getVersion() );
+
+        // An application runs on exactly one engine, so it is tested on exactly that one — the same
+        // value that becomes its X-Script-Engine header. Left unset it stays empty rather than
+        // guessing, which keeps `test` on whatever the XP version being built against defaults to.
+        this.ext.getScriptEngines()
+            .convention( this.appExt.getScriptEngine().map( List::of ).orElse( List.of() ) );
 
         this.project.afterEvaluate( this::afterEvaluate );
 

--- a/src/test/java/com/enonic/gradle/xp/ScriptEngineTestsFunctionalTest.java
+++ b/src/test/java/com/enonic/gradle/xp/ScriptEngineTestsFunctionalTest.java
@@ -1,0 +1,138 @@
+package com.enonic.gradle.xp;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The engine matrix is resolved after the build script has run, so these go through a real build
+ * rather than a synthetic project.
+ */
+class ScriptEngineTestsFunctionalTest
+{
+    @TempDir
+    File projectDir;
+
+    /**
+     * The plugin's toolchain convention is the current XP baseline, which the machine running these
+     * tests need not have installed. Pinning the probe build to the running JVM keeps them from
+     * depending on that.
+     */
+    private static final String TOOLCHAIN = "java { toolchain { languageVersion = JavaLanguageVersion.of(" +
+        Runtime.version().feature() + ") } }\n";
+
+    /**
+     * Reports what the wiring produced: which extra test tasks exist, what engine each task got,
+     * and whether {@code check} picked the extra ones up.
+     */
+    private static final String REPORT_TASK = "tasks.register('reportEngines') {\n" +
+        "    doLast {\n" +
+        "        tasks.withType(Test).sort { it.name }.each { t ->\n" +
+        "            println 'TASK=' + t.name + ' engine=' + t.systemProperties['xp.script-engine']\n" +
+        "        }\n" +
+        "        println 'CHECK=' + tasks.check.taskDependencies.getDependencies(tasks.check)*.name.sort().join(',')\n" +
+        "    }\n" +
+        "}\n";
+
+    private void writeFile( final String name, final String content )
+        throws IOException
+    {
+        Files.writeString( new File( projectDir, name ).toPath(), content );
+    }
+
+    private BuildResult run()
+    {
+        return GradleRunner.create()
+            .withProjectDir( projectDir )
+            .withPluginClasspath()
+            .withArguments( "reportEngines", "-q" )
+            .build();
+    }
+
+    private String build( final String plugins, final String config )
+        throws IOException
+    {
+        writeFile( "settings.gradle", "plugins { id 'com.enonic.xp.settings' }\nrootProject.name = 'probe'\n" );
+        writeFile( "build.gradle", "plugins {\n" + plugins + "}\n" + TOOLCHAIN + config + REPORT_TASK );
+        return run().getOutput();
+    }
+
+    @Test
+    void aLibraryIsTestedOnEveryEngine()
+        throws IOException
+    {
+        final String output = build( "    id 'java'\n    id 'com.enonic.xp.base'\n", "" );
+
+        // the task name follows the engine name, so GraalJS gives testGraalJS
+        assertTrue( output.contains( "TASK=test engine=Nashorn" ), output );
+        assertTrue( output.contains( "TASK=testGraalJS engine=GraalJS" ), output );
+
+        // and it has to be reachable from check, or a library would never run the second engine
+        assertTrue( output.lines().anyMatch( line -> line.startsWith( "CHECK=" ) && line.contains( "testGraalJS" ) ), output );
+    }
+
+    @Test
+    void anApplicationIsTestedOnTheEngineItDeclares()
+        throws IOException
+    {
+        final String output = build( "    id 'java'\n    id 'com.enonic.xp.app'\n", "app { scriptEngine = 'GraalJS' }\n" );
+
+        // the engine it will actually run on, and only that one
+        assertTrue( output.contains( "TASK=test engine=GraalJS" ), output );
+        assertFalse( output.contains( "TASK=testNashorn" ), output );
+        assertFalse( output.contains( "TASK=testGraalJS" ), output );
+    }
+
+    @Test
+    void anApplicationWithoutADeclaredEngineIsLeftAlone()
+        throws IOException
+    {
+        final String output = build( "    id 'java'\n    id 'com.enonic.xp.app'\n", "" );
+
+        // no property, so the harness applies the default of the XP version being built against
+        assertTrue( output.contains( "TASK=test engine=null" ), output );
+        assertFalse( output.contains( "TASK=testGraalJS" ), output );
+    }
+
+    @Test
+    void aProjectCanNarrowTheMatrixItself()
+        throws IOException
+    {
+        final String output = build( "    id 'java'\n    id 'com.enonic.xp.base'\n", "xp { scriptEngines = ['Nashorn'] }\n" );
+
+        assertTrue( output.contains( "TASK=test engine=Nashorn" ), output );
+        assertFalse( output.contains( "TASK=testGraalJS" ), output );
+    }
+
+    @Test
+    void engineTasksRunTheSameTestsAsTheTestTask()
+        throws IOException
+    {
+        writeFile( "settings.gradle", "plugins { id 'com.enonic.xp.settings' }\nrootProject.name = 'probe'\n" );
+        writeFile( "build.gradle", "plugins {\n    id 'java'\n    id 'com.enonic.xp.base'\n}\n" + TOOLCHAIN +
+            "tasks.register('compareClasspaths') {\n" +
+            "    doLast {\n" +
+            "        println 'SAME_DIRS=' + (tasks.testGraalJS.testClassesDirs.files == tasks.test.testClassesDirs.files)\n" +
+            "        println 'SAME_CP=' + (tasks.testGraalJS.classpath.files == tasks.test.classpath.files)\n" +
+            "    }\n" +
+            "}\n" );
+
+        final String output = GradleRunner.create()
+            .withProjectDir( projectDir )
+            .withPluginClasspath()
+            .withArguments( "compareClasspaths", "-q" )
+            .build()
+            .getOutput();
+
+        assertTrue( output.contains( "SAME_DIRS=true" ), output );
+        assertTrue( output.contains( "SAME_CP=true" ), output );
+    }
+}


### PR DESCRIPTION
Closes #222

Every XP library and application with JS-executing tests currently hand-writes its own dual-engine test wiring. [enonic/lib-qrcode#66](https://github.com/enonic/lib-qrcode/pull/66) is representative: 4 test dependencies, 2 version-catalog entries, a 10-line `testGraalJs` task, `check.dependsOn`, and knowledge of the `xp.script-engine` property name — a near-copy of `gradle/js-tests.gradle` in the xp repo, repeated per project and kept in sync by hand.

## What this does

`BasePlugin` derives the engine set from the project and registers the test tasks, so neither a library nor an application writes any of it:

| Project | Result |
|---|---|
| library (`com.enonic.xp.base` only) | `test` on Nashorn + `testGraalJS` on GraalJS, both reachable from `check` |
| application with `app { scriptEngine = 'GraalJS' }` | `test` on GraalJS, no extra task |
| application with no declared engine | `test` untouched, so it follows the default of the XP version being built against |
| any project with `xp { scriptEngines = [...] }` | exactly what it asks for |

This needed no new DSL on the application side. `AppExtension.scriptEngine` already exists and already feeds the `X-Script-Engine` bundle header (`BundleConfigurator:73`), which is what the runtime reads to pick an application's engine — so the value that governs production now also governs the tests, and the two cannot drift. Library-versus-application is likewise already answerable: only an application applies `AppPlugin`, so only an application has an `AppExtension`.

`com.enonic.xp:testing` is also added to the `xplibs` catalog, so builds stop spelling out `"com.enonic.xp:testing:${xpVersion}"`.

## Two decisions worth reviewing

**Each task names its engine explicitly** rather than letting `test` inherit the platform default. If it inherited, then on the day XP changes its default engine both `test` and the extra task would run the new default, and coverage of the other engine would disappear with nothing failing. An application that declares no engine is the one case left to inherit, deliberately — it should follow the XP version it builds against rather than a default baked in here.

**The task name is `testGraalJS`**, derived mechanically from the engine name — the same string used in `app { scriptEngine }` and in the manifest header. Note this differs by one letter from the `testGraalJs` that projects have been hand-writing. Happy to special-case the spelling to match existing habit if preferred; I avoided a name-mapping table on purpose, but it is a one-line change.

## Verification

Five functional tests through `GradleRunner` cover each row of the table above plus the fact that an engine task runs the same classes and classpath as `test`. Full suite is green (25 tests).

Beyond that, checked end to end against a real library: with the plugin published to mavenLocal, **14 lines were deleted** from lib-qrcode#66's build and `check` still ran both engines —

```
> Task :test
> Task :testGraalJS
> Task :check
BUILD SUCCESSFUL
```

Two findings came out of that exercise, both outside this repo:

- The first end-to-end run failed on GraalJS with `IllegalStateException: The Context is already closed.` from `ScriptRunnerSupport`. That is a platform bug fixed in enonic/xp#12198 and not yet in a published snapshot, so libraries using `ScriptRunnerSupport` cannot get a green GraalJS run until it merges. Libraries using `ScriptTestSupport` are unaffected — lib-cron runs green on both engines against released 8.0.2 today.
- A library still needs `testRuntimeOnly` for the GraalJS language implementation, because `script-impl` publishes only the polyglot API. enonic/xp#12198 now has `com.enonic.xp:testing` carry it at runtime scope, after which no build names a GraalVM version at all.

## Follow-up, not in this PR

Running both engines inside a single test JVM. That is feasible — the harness builds its engine facade fresh per test setup, and one JVM will run the same script on Nashorn, then GraalJS, then Nashorn again, picking the right engine each time — and it would pay Truffle warmup once instead of twice and report results as `testFoo[GraalJS]`. It needs a change in the testing framework too, but the plugin-to-framework contract is the same either way (an engine list), so it can land later without touching any build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oz9cKabh9NMDhDt164DAM


---
_Generated by [Claude Code](https://claude.ai/code/session_013oz9cKabh9NMDhDt164DAM)_