### PR TITLE
Default the test engine matrix to Nashorn only #225

### DIFF
--- a/src/main/java/com/enonic/gradle/xp/XpExtension.java
+++ b/src/main/java/com/enonic/gradle/xp/XpExtension.java
@@ -14,10 +14,12 @@ import org.gradle.api.provider.Property;
 public class XpExtension
 {
     /**
-     * What a library is tested on by default. A library declares no engine of its own — it runs
-     * inside whatever application requires it — so its tests have to pass on every engine.
+     * What a project is tested on when it declares nothing. Only Nashorn: it is the engine every
+     * supported XP version can run, so this default never asks for one the version being built
+     * against cannot provide. A project that also wants GraalJS coverage opts in through
+     * {@code xp.scriptEngines}, and does so against an XP version whose testing framework ships it.
      */
-    private static final List<String> ALL_SCRIPT_ENGINES = List.of( "Nashorn", "GraalJS" );
+    private static final List<String> DEFAULT_SCRIPT_ENGINES = List.of( "Nashorn" );
 
     private final Project project;
 
@@ -45,7 +47,7 @@ public class XpExtension
                                      .orElse( project.getLayout().getBuildDirectory().dir( "xp/home" ) ) );
 
         this.scriptEngines = objects.listProperty( String.class );
-        this.scriptEngines.convention( ALL_SCRIPT_ENGINES );
+        this.scriptEngines.convention( DEFAULT_SCRIPT_ENGINES );
     }
 
     private static String xplibsCatalogVersion( final Project project )
@@ -83,9 +85,11 @@ public class XpExtension
 
     /**
      * The script engines the tests of this project run on, in order: the first is the one the
-     * {@code test} task uses, and every other one gets a task of its own. An application narrows
-     * this to the single engine it declares; an empty list leaves {@code test} alone, so it follows
-     * the default of the XP version being built against.
+     * {@code test} task uses, and every other one gets a task of its own. Defaults to Nashorn
+     * alone; add GraalJS to also generate a {@code testGraalJS} task, but only against an XP version
+     * whose testing framework ships GraalJS. An application narrows this to the single engine it
+     * declares; an empty list leaves {@code test} alone, so it follows the default of the XP version
+     * being built against.
      */
     public ListProperty<String> getScriptEngines()
     {

--- a/src/test/java/com/enonic/gradle/xp/ScriptEngineTestsFunctionalTest.java
+++ b/src/test/java/com/enonic/gradle/xp/ScriptEngineTestsFunctionalTest.java
@@ -66,16 +66,29 @@ class ScriptEngineTestsFunctionalTest
     }
 
     @Test
-    void aLibraryIsTestedOnEveryEngine()
+    void aLibraryIsTestedOnNashornByDefault()
         throws IOException
     {
         final String output = build( "    id 'java'\n    id 'com.enonic.xp.base'\n", "" );
+
+        // only the engine every supported XP version can run: nothing that a version being built
+        // against might not provide is asked for unless the project opts in
+        assertTrue( output.contains( "TASK=test engine=Nashorn" ), output );
+        assertFalse( output.contains( "TASK=testGraalJS" ), output );
+    }
+
+    @Test
+    void aProjectCanOptIntoAnotherEngine()
+        throws IOException
+    {
+        final String output =
+            build( "    id 'java'\n    id 'com.enonic.xp.base'\n", "xp { scriptEngines = ['Nashorn', 'GraalJS'] }\n" );
 
         // the task name follows the engine name, so GraalJS gives testGraalJS
         assertTrue( output.contains( "TASK=test engine=Nashorn" ), output );
         assertTrue( output.contains( "TASK=testGraalJS engine=GraalJS" ), output );
 
-        // and it has to be reachable from check, or a library would never run the second engine
+        // and it has to be reachable from check, or the extra engine would never run
         assertTrue( output.lines().anyMatch( line -> line.startsWith( "CHECK=" ) && line.contains( "testGraalJS" ) ), output );
     }
 
@@ -103,21 +116,12 @@ class ScriptEngineTestsFunctionalTest
     }
 
     @Test
-    void aProjectCanNarrowTheMatrixItself()
-        throws IOException
-    {
-        final String output = build( "    id 'java'\n    id 'com.enonic.xp.base'\n", "xp { scriptEngines = ['Nashorn'] }\n" );
-
-        assertTrue( output.contains( "TASK=test engine=Nashorn" ), output );
-        assertFalse( output.contains( "TASK=testGraalJS" ), output );
-    }
-
-    @Test
     void engineTasksRunTheSameTestsAsTheTestTask()
         throws IOException
     {
         writeFile( "settings.gradle", "plugins { id 'com.enonic.xp.settings' }\nrootProject.name = 'probe'\n" );
         writeFile( "build.gradle", "plugins {\n    id 'java'\n    id 'com.enonic.xp.base'\n}\n" + TOOLCHAIN +
+            "xp { scriptEngines = ['Nashorn', 'GraalJS'] }\n" +
             "tasks.register('compareClasspaths') {\n" +
             "    doLast {\n" +
             "        println 'SAME_DIRS=' + (tasks.testGraalJS.testClassesDirs.files == tasks.test.testClassesDirs.files)\n" +


### PR DESCRIPTION
Fixes #225

Since #223 a library defaults its test engine matrix to `["Nashorn", "GraalJS"]`, generating a `testGraalJS` task wired into `check`. That assumes every XP version a library builds against can run GraalJS — but `com.enonic.xp:testing:8.0.x` pulls `script-impl:8.0.x`, which ships only the `org.graalvm.polyglot:polyglot` API and no `org.graalvm.polyglot:js` language. GraalJS is runnable only from 8.1.0, so a library pinned to `xpVersion=8.0.x` (e.g. `lib-router` on `8.0.2`) gets a `testGraalJS` task that fails at engine init.

This defaults `xp.scriptEngines` to `["Nashorn"]` alone — the one engine every supported XP version can run. GraalJS coverage becomes opt-in:

```groovy
xp { scriptEngines = ['Nashorn', 'GraalJS'] }
```

used only against an XP version (8.1.0+) whose testing framework actually ships GraalJS. The plugin still needs no `xpVersion` comparison, and the opt-in lines up with the ongoing GraalJS-compatibility migration.

### Behaviour

| Project | Before | After |
| --- | --- | --- |
| Library (base plugin) | `test`=Nashorn **+ `testGraalJS`** | `test`=Nashorn |
| Library opting in via `scriptEngines` | n/a | `test`=Nashorn + `testGraalJS` |
| App with `app.scriptEngine` | pins that engine | unchanged |
| App without a declared engine | `test` follows platform default | unchanged |

Functional tests updated to match; `aLibraryIsTestedOnEveryEngine` becomes `aLibraryIsTestedOnNashornByDefault`, with the GraalJS-generation/`check`-wiring assertions moved to a new opt-in test.

> Note: not built/tested locally — no JVM on the authoring host. Relying on CI to run `./gradlew test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
